### PR TITLE
Fix db/generated being included in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,4 +16,4 @@ node_modules
 yarn-error.log
 Dockerfile
 *compose.yml
-db/generatd
+db/generated


### PR DESCRIPTION
Due to a typo in .dockerignore, the prisma generated client is included when COPYing db.

This brings an unnecessary ~15MB dependency when building an image while using your local dev folder as the docker build context (as the binary has a different name):

### Before:
![image](https://github.com/paavohuhtala/saituri-9000/assets/21111572/a9cd0a0a-2538-4180-8bfe-d50278dade54)


### After:
![image](https://github.com/paavohuhtala/saituri-9000/assets/21111572/4e52fd2c-7a2e-48e6-9cb6-4891d7d013ee)
