### PR TITLE
Fix no decimal on iOS 16.5 keyboard when entering expense amount

### DIFF
--- a/src/frontend/expense/ExpenseEditor.tsx
+++ b/src/frontend/expense/ExpenseEditor.tsx
@@ -143,7 +143,7 @@ export function ExpenseEditor({ initialExpense, expenseGroup, members, onSaveExp
         <FormLabel>Summa €</FormLabel>
         <InputField
           placeholder="esim. 6,66"
-          inputMode="numeric"
+          inputMode="decimal"
           onChange={(event) => {
             setPendingAmount(event.target.value);
           }}


### PR DESCRIPTION
On iOS, it appears that the numeric inputMode doesn't show a decimal point, which makes entering expense values awkward.

> ![IMG_7021](https://github.com/paavohuhtala/saituri-9000/assets/21111572/016eeebd-0888-4816-afe8-bd5e4a65948f)

Could not test right now, maybe it works
